### PR TITLE
Fixes http(s) and browser compatibility in Cabin font import

### DIFF
--- a/app/assets/stylesheets/_bootswatch.scss
+++ b/app/assets/stylesheets/_bootswatch.scss
@@ -3,7 +3,7 @@
 // -----------------------------------------------------
 
 @import url("//fonts.googleapis.com/css?family=Raleway:400,700");
-@import url(http://fonts.googleapis.com/css?family=Cabin:400,600,700,500italic);
+@import url("//fonts.googleapis.com/css?family=Cabin:400,600,700,500italic");
 
 // Navbar =====================================================================
 


### PR DESCRIPTION
This removes the http from the Cabin font import and makes the path relative so it doesn't break in https. It also uses proper double quotes for browser compatibility.